### PR TITLE
fix: allow multiple asdf output files per input

### DIFF
--- a/metacopy-with-contextl.asd
+++ b/metacopy-with-contextl.asd
@@ -16,12 +16,16 @@
 
 (defmethod output-files :around ((operation operation) (component metacopy-file-with-contextl))
   (with-contextl
-    (let* ((paths (call-next-method))
-           (file (first paths)))
-      (when paths
-        (setf paths (remove-if (lambda (s) (string= (asdf/lisp-build:warnings-file-type) (pathname-type s))) paths))
-        (assert (<= (length paths) 1))
-        (list (merge-pathnames (concatenate 'string (pathname-name file) "-contextl") file))))))
+    (let ((paths (call-next-method)))
+      ;; Any output files also get -contextl added. This used to filter out any
+      ;; “warnings file” (cf. uiop:*warnings-file-type*), but that check has
+      ;; been removed because it seems to cause more trouble than it is
+      ;; worth. If there is a problem arising from the renaming of warning
+      ;; files, this is where to restore the filter.
+      (mapcar (lambda (path)
+                (make-pathname :name (concatenate 'string (pathname-name path) "-contextl")
+                               :defaults path))
+              paths))))
 
 ;;; and the system that will load the entire metacopy code again into another package called :metacopy-with-contextl
 (defsystem "metacopy-with-contextl"


### PR DESCRIPTION
This (partially) reverts commit 9c90a059a5d920ddffaf52a5f72ec46dbcd20737.

Fixes #2.

It’s not clear to me why the assert was originally added, but it looks like a sanity check for the surrounding “don’t translate warning files” code. I’ve also removed that, tentatively, because, again, my intuition tells me that it can go. I’m less confident about this one though so if there’s a problem, feel free to restore.